### PR TITLE
Add mailto prefix to gmail icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 <a href="https://www.hackerrank.com/Hemdan?hr_r=1">
   <img align="left" alt="hemdan's hackerrank" width="30px" src="https://assets.brandfolder.com/y9ol94wb/v/331198/view@2x.png?v=1591971279" draggable="false" />
 </a>
-<a href="abdallah.ahmed.hemdan@gmail.com">
+<a href="mailto:abdallah.ahmed.hemdan@gmail.com">
   <img align="left" alt="hemdan's gmail" width="30px" src="https://image.flaticon.com/icons/svg/732/732200.svg" draggable="false" />
 </a>
 


### PR DESCRIPTION
Add Mailto link to activate the default mail client.